### PR TITLE
Add project maintenance manual

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,25 @@
+# uX maintainence manual
+
+The project maintainers are the users designated as owners of the project's GitHub organization.
+
+We use pull requests to review changes to the master branch.
+Generally, before merging, pull requests should be reviewed by a maintainer
+who is not also the author of the PR.
+
+## Development goals
+
+* Basic properties of the types in uX are advertised already in the README:
+  Behave as close as possible to the corresponding builtin type,
+  be stored like them,
+  and give the compiler as much information as practical to work with them
+  (eg. advertising niches).
+* Builtin types often have traits implemented for them in third party crates.
+  We encourage these third parties to optionally depend on uX
+  and implement the traits for these types as well;
+  when that is impossible for some reason,
+  we may add an optional dependency and implement the traits here instead.
+* On the long run,
+  this crate's goal is to be obsoleted by ranged integers in the core library.
+  When that happens
+  (and there is at least [an issue](https://github.com/rust-lang/rfcs/issues/671) open),
+  this crate can be demoted to a compatibility wrapper.


### PR DESCRIPTION
As we're now multiple people maintaining this, and because I generally prefer to know which rules to play, I'd like to suggest this maintenance manual (especially when I have more rights on something than I'd like to exercise).

If we all like this (for lack of precedent, I'd like to have at least two of the current maintainers' positive review on this before going ahead), we may or may not go through the effort of setting up all the branch protection and checks and what-so-not, but to me, knowing what I may or may not do on my own would be a good starting point.

Note that I don't mention doing releases or other large project changes (like altering the maintenance manual), because these typically come from maintainers anyway -- and thus need a second maintainer to clear them, which is what I think would be good.