### PR TITLE
Implement std::error::Error for TryFromIntError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["embedded", "no-std", "data-structures"]
 
 [features]
 default = []
-# This is a no-op feature only provided for compatibility in case it is
-# explicitly selected by a user. This crate works without explicit indication
-# both on std and no_std systems.
+# The std feature only toggles whether the Error trait is implemented for error
+# types. Apart from that, this crate works without explicit indication both on
+# std and no_std systems.
 std = []

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -16,6 +16,15 @@ impl From<lib::core::convert::Infallible> for TryFromIntError {
     }
 }
 
+impl Display for TryFromIntError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "out of range integral type conversion attempted")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TryFromIntError {}
+
 // Only implement if $from can be converted into $name lossless
 macro_rules! implement_from {
     {[$($name:ident),*], [$($from:ident),*] } => {$(implement_from!($name, $from);)*};
@@ -1828,5 +1837,14 @@ mod tests {
 
         assert!(i6::try_from(i7(64)).is_err());
         assert!(i6::try_from(i7(-64)).is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn error_trait() {
+        assert_eq!(
+            (&TryFromIntError(()) as &dyn std::error::Error).to_string(),
+            "out of range integral type conversion attempted"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! and thus does not use it:
 //! an `Option<u7>` still takes up two bytes.
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 mod lib {
     pub use core;


### PR DESCRIPTION
.. which unfortunately requires `std` until `error_in_core` (rust-lang/rust#103765) is stabilized, so the `std` feature is no longer a no-op. If that means you'd prefer to wait for `error_in_core`, that's fine with me.

The net result here is that `TryFromIntError` plays nice with crates such as `anyhow`, and the following compiles:
```rust
#[cfg(feature = "std")]
mod test_anyhow {
    use anyhow::Result;
    use super::*;
    fn testing_anyhow() -> Result<u6> {
        Ok(u6::try_from(u63::new(63))?)
    }
}
```

The error description is copied verbatim from its `std::num` counterpart: https://doc.rust-lang.org/src/core/num/error.rs.html#24