### PR TITLE
Bugfix | Fixes not operator creating invalid types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,7 +339,7 @@ macro_rules! implement_common {
             type Output = $name;
 
             fn not(self) -> $name {
-                $name(self.mask().0.not())
+                $name(self.0.not()).mask()
             }
         }
 
@@ -347,7 +347,7 @@ macro_rules! implement_common {
             type Output = <$name as Not>::Output;
 
             fn not(self) -> $name {
-                $name(self.mask().0.not())
+                $name(self.0.not()).mask()
             }
         }
 
@@ -969,5 +969,10 @@ mod tests {
         assert_eq!(!u7(0x7F), u7(0));
         assert_eq!(!u7(0), u7(0x7F));
         assert_eq!(!u7(56), u7(71));
+    }
+
+    #[test]
+    fn test_not_creates_valid_repr() {
+        assert_eq!((!u4(0b0101)).0, 0b1010);
     }
 }


### PR DESCRIPTION
## The Issue

The implementation of the `Not` operator has a bug where it creates types with invalid representations, which in turn leads to panics when the type is used.

For example.
```
let _ = !u4(0b0101); // this u4 has a value of u4(0b1111_1010) -> invalid!
```

Using such an invalid type will result in a panic:
```
let _ = !u4(5) + u4(1);
// -> assertion failed: Self::MAX.0 - other.0 >= self.0
```

The unit tests did not catch this one because the equality `PartialEq` implementation ignores the bits in the representation which lie outside the type mask.

## The Fix

The not operator should ensure not to flip the bits of the underlying value which lie outside of the type mask.