### PR TITLE
Expose `TryFromIntError`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod lib {
 }
 
 mod conversion;
+pub use conversion::TryFromIntError;
 
 use lib::core::ops::{
     BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, ShlAssign, Shr,


### PR DESCRIPTION
This is needed to be able to create conversion from ux error into custom errors (like with thiserror).