### PR TITLE
Feature | Integration with the arbitrary crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,3 +38,12 @@ jobs:
     - name: Run tests
       run: cargo test --verbose --features std
 
+  build_arbitrary:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose --features arbitrary
+    - name: Run tests
+      run: cargo test --verbose --features arbitrary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["embedded", "no-std", "data-structures"]
 
 
 [dependencies]
+arbitrary = { version = "1.4.1", optional = true }
 
 [features]
 default = []
@@ -23,3 +24,4 @@ default = []
 # types. Apart from that, this crate works without explicit indication both on
 # std and no_std systems.
 std = []
+arbitrary = ["dep:arbitrary"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,6 +383,13 @@ macro_rules! implement_common {
                 self.wrapping_sub(other)
             }
         }
+
+        #[cfg(feature = "arbitrary")]
+        impl<'a> arbitrary::Arbitrary<'a> for $name {
+            fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+                Ok($name($type::arbitrary(u)?).mask())
+            }
+        }
     };
 }
 
@@ -965,5 +972,25 @@ mod tests {
             SEVEN => panic!("Pattern matching failed (7 == 42?)"),
             _ => (),
         }
+    }
+}
+
+#[cfg(all(test, feature = "arbitrary"))]
+mod tests_arbitrary {
+    use super::*;
+    use arbitrary::Arbitrary;
+
+    #[test]
+    fn generate_from_unstructured_data() {
+        let data = [0x0, 0x0, 0x0, 0x0];
+        let mut unstructured = arbitrary::Unstructured::new(&data);
+        assert_eq!(u31::arbitrary(&mut unstructured), Ok(u31(0x0)));
+    }
+
+    #[test]
+    fn data_is_masked_appropriately_on_generation() {
+        let data = [0xFF, 0xFF, 0xFF, 0xFF];
+        let mut unstructured = arbitrary::Unstructured::new(&data);
+        assert_eq!(u31::arbitrary(&mut unstructured), Ok(u31(0x7FFFFFFF)));
     }
 }


### PR DESCRIPTION
## The Feature

Adds an optional feature to ux which will add integration with [arbitrary](https://crates.io/crates/arbitrary).

When the feature is enabled (opt-in) the `arbitrary::Arbitrary` trait is implemented for all the types from ux. This allows ux types to be generated from raw, unstructured data, particularly useful in a fuzz testing context.